### PR TITLE
Added option to allow the users to perform the request using their own API Keys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@types/bun": "latest",
       },
       "peerDependencies": {
-        "typescript": "^5",
+        "typescript": "^5.9.3",
       },
     },
   },

--- a/server/steam.ts
+++ b/server/steam.ts
@@ -120,7 +120,14 @@ export class SteamIdentifierError extends Error {
 	}
 }
 
-export async function getVanityResolution(rawIdentifier: string) {
+interface GetVanityResolutionOptions {
+	apiKeyOverride?: string;
+}
+
+export async function getVanityResolution(
+	rawIdentifier: string,
+	options?: GetVanityResolutionOptions,
+) {
 	const identifier = rawIdentifier.trim();
 
 	if (!identifier) {
@@ -139,7 +146,7 @@ export async function getVanityResolution(rawIdentifier: string) {
 	console.log(`No cached vanity resolution for "${identifier}", fetching...`);
 	let apiKey: string;
 	try {
-		apiKey = resolveSteamApiKey();
+		apiKey = resolveSteamApiKey(options?.apiKeyOverride);
 	} catch (error) {
 		const message =
 			error instanceof Error

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1530,6 +1530,13 @@
 			showError({
 				title: 'Steam profile required',
 				body: 'Add a SteamID or vanity username to the URL (e.g. /76561198000000000 or /obviyus) to view your collage.',
+				actions: [
+					{
+						label: 'Go to Home',
+						href: '/',
+						external: false,
+					},
+				],
 			});
 		} else {
 			try {
@@ -1572,6 +1579,13 @@
 					title: 'Unable to load playtime data',
 					body: "We couldn't load the playtime data.",
 					hint: 'If this is your profile, make sure your Steam Game Details privacy is set to Public and try again.',
+					actions: [
+						{
+							label: 'Go to Home',
+							href: '/',
+							external: false,
+						},
+					],
 				};
 
 				if (status === 404) {
@@ -1581,6 +1595,11 @@
 						hint: 'Use the ID from your profile URL (steamcommunity.com/id/... or /profiles/...) or the full steamID64.',
 						disableRefresh: true,
 						actions: [
+							{
+								label: 'Go to Home',
+								href: '/',
+								external: false,
+							},
 							{
 								label: 'Open steamid.io',
 								href: 'https://steamid.io/lookup',
@@ -1593,6 +1612,13 @@
 						title: 'Profile is private',
 						body: 'This Steam profile keeps its game details private.',
 						hint: 'Update privacy settings to Public and try again.',
+						actions: [
+							{
+								label: 'Go to Home',
+								href: '/',
+								external: false,
+							},
+						],
 					};
 				} else if (
 					errorMessage &&
@@ -1602,6 +1628,13 @@
 					errorConfig = {
 						title: 'Unable to load playtime data',
 						body: errorMessage,
+						actions: [
+							{
+								label: 'Go to Home',
+								href: '/',
+								external: false,
+							},
+						],
 					};
 				}
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -404,6 +404,10 @@
 			: null;
 		let displayIdentifier = submittedIdentifier;
 
+		// Extract API key from URL query parameters
+		const urlParams = new URLSearchParams(window.location.search);
+		const userApiKey = urlParams.get('apiKey') || '';
+
 		const PAGE_TITLE_BASE = "Playtime Panorama";
 		const updateDocumentTitle = (identifier) => {
 			const next = typeof identifier === "string" ? identifier.trim() : "";
@@ -864,15 +868,20 @@
 				throw new Error('Missing Steam identifier for refresh.');
 			}
 
-			const response = await fetch(
+			const refreshUrl = new URL(
 				`${API_ENDPOINT_BASE}${encodeURIComponent(lookupIdentifier)}${REFRESH_ENDPOINT_SUFFIX}`,
-				{
-					method: 'POST',
-					headers: {
-						Accept: 'application/json',
-					},
-				},
+				window.location.origin
 			);
+			if (userApiKey) {
+				refreshUrl.searchParams.set('apiKey', userApiKey);
+			}
+
+			const response = await fetch(refreshUrl.toString(), {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+				},
+			});
 
 			if (response.status === 429) {
 				const retryPayload = await response.json().catch(() => ({}));
@@ -1526,7 +1535,11 @@
 			try {
 				showLoader();
 				const lookupIdentifier = submittedIdentifier;
-				const response = await fetch(`${API_ENDPOINT_BASE}${encodeURIComponent(lookupIdentifier)}`, {
+				const apiUrl = new URL(`${API_ENDPOINT_BASE}${encodeURIComponent(lookupIdentifier)}`, window.location.origin);
+				if (userApiKey) {
+					apiUrl.searchParams.set('apiKey', userApiKey);
+				}
+				const response = await fetch(apiUrl.toString(), {
 					headers: {
 						Accept: 'application/json',
 					},

--- a/templates/root.html
+++ b/templates/root.html
@@ -196,6 +196,11 @@
 				<small>Examples: obviyus, 76561198814583839.</small>
 			</label>
 			<input id="steam-id" name="steam-id" placeholder="obviyus" required autocomplete="off" />
+			<label for="steam-api-key">
+				Steam API Key (optional)
+				<small>If provided, your personal API key will be used instead of the server's key.</small>
+			</label>
+			<input id="steam-api-key" name="steam-api-key" type="password" placeholder="Enter your Steam API key (optional)" autocomplete="off" />
 			<div class="form-actions">
 				<button type="submit" class="cta-button">
 					<span class="cta-button__label">View playtime collage</span>
@@ -243,10 +248,14 @@
 			event.preventDefault();
 			const formData = new FormData(form);
 			const targetId = normalizeSteamIdentifier(formData.get('steam-id'));
+			const apiKey = formData.get('steam-api-key');
 
 			if (targetId) {
-				const url = '/' + encodeURIComponent(targetId);
-				window.location.assign(url);
+				const url = new URL('/' + encodeURIComponent(targetId), window.location.origin);
+				if (apiKey && typeof apiKey === 'string' && apiKey.trim()) {
+					url.searchParams.set('apiKey', apiKey.trim());
+				}
+				window.location.assign(url.toString());
 			}
 		});
 	</script>

--- a/templates/root.html
+++ b/templates/root.html
@@ -156,6 +156,16 @@
 			color: #8a8a8a;
 		}
 
+		small a {
+			color: #ffffff;
+			text-decoration: underline;
+			transition: color 150ms ease;
+		}
+
+		small a:hover {
+			color: #dddddd;
+		}
+
 		footer {
 			font-size: 0.875rem;
 			color: #888888;
@@ -198,7 +208,11 @@
 			<input id="steam-id" name="steam-id" placeholder="obviyus" required autocomplete="off" />
 			<label for="steam-api-key">
 				Steam API Key (optional)
-				<small>If provided, your personal API key will be used instead of the server's key.</small>
+				<small>
+					If the profile generation fails, it's probably because my own API Key have reached the usage limit.
+					If provided, your personal API key will be used instead of the default server's key.
+					<a href="https://steamcommunity.com/dev/apikey" target="_blank" rel="noreferrer">Get your API key here</a>.
+				</small>
 			</label>
 			<input id="steam-api-key" name="steam-api-key" type="password" placeholder="Enter your Steam API key (optional)" autocomplete="off" />
 			<div class="form-actions">
@@ -212,8 +226,9 @@
 			<ol>
 				<li>Visit your Steam profile in a browser and choose <strong>Edit Profile</strong>.</li>
 				<li>Open <strong>My privacy settings</strong>.</li>
-				<li>Set <strong>Game details</strong> to <strong>Public</strong> and uncheck “Always keep my total
-					playtime private even if users can see my game details.”</li>
+				<li>Set <strong>Game details</strong> to <strong>Public</strong> and uncheck "Always keep my total
+					playtime private even if users can see my game details."</li>
+				<li>API keys are not stored on the server. Results are cached for 24 hours to improve performance and reduce API usage.</li>
 			</ol>
 		</div>
 	</main>


### PR DESCRIPTION
Hey, it's a cool project and I had some free time while dinner was cooking 😄 

You can simply launch the docker compose without specifying an api key and all requests will always require a user key, or launch it as it is now, and when the API limit is reached it will fail and need the users to add their own api keys.

I also added more info in the root view that explain why the user API key might be needed and that it is not stored anywhere. Also that results are cached for 24h.

Tested with local bun run, not docker (run out of time) but honestly it should just work!

Feel free to modify. Cheers!